### PR TITLE
Remove magic PTR attributes

### DIFF
--- a/docs/resources/dns_zone_record.md
+++ b/docs/resources/dns_zone_record.md
@@ -87,7 +87,6 @@ resource "technitium_dns_zone_record" "ptr" {
 - `class_path` (String) DNS app class path
 - `cname` (String)
 - `comments` (String)
-- `create_ptr_zone` (Boolean) Set this option to true to create a reverse zone for PTR record. This option is used for A and AAAA records
 - `disabled` (Boolean) Set to true to disable the DNS record. Default is false.
 - `dnssec_validation` (Boolean)
 - `exchange` (String) The exchange domain name. This option is required for adding MX record.
@@ -103,7 +102,6 @@ resource "technitium_dns_zone_record" "ptr" {
 - `proxy_port` (Number)
 - `proxy_type` (String) The type of proxy to be used for conditional forwarding. Valid values are [`NoProxy`, `DefaultProxy`, `Http`, `Socks5`].
 - `proxy_username` (String)
-- `ptr` (Boolean) Set to true to add a reverse PTR record for the IP address in the A or AAAA record. This option is used only for A and AAAA records.
 - `ptr_name` (String)
 - `record_data` (String) DNS app record data
 - `split_text` (String) Set to true for using new line char to split text into multiple character-strings for adding TXT record.

--- a/internal/provider/resource_schemas.go
+++ b/internal/provider/resource_schemas.go
@@ -164,14 +164,6 @@ func DnsZoneRecordResourceSchema() map[string]schema.Attribute {
 		"ip_address": schema.StringAttribute{
 			Optional: true,
 		},
-		"ptr": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Set to true to add a reverse PTR record for the IP address in the A or AAAA record. This option is used only for A and AAAA records.",
-		},
-		"create_ptr_zone": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Set this option to true to create a reverse zone for PTR record. This option is used for A and AAAA records",
-		},
 		"update_svcb_hints": schema.BoolAttribute{
 			Optional: true,
 		},


### PR DESCRIPTION
Remove `ptr` and `create_ptr_zone` attributes. These are part of the "magic" API options that create additional resources behind the scenes, making them impossible to track in the terraform state.